### PR TITLE
Fix value error in info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "TheF1ng3r",
+    "author": ["TheF1ng3r"],
     "name": "Finger-Cogs",
     "short": "Fun and helpful cogs",
     "description": "Set of cogs that will bring more fun and utility to your bot.",


### PR DESCRIPTION
The value of author key in info.json must be a list, this raises an error on each restart of the bot.
![image](https://user-images.githubusercontent.com/65814383/135231712-1f77a087-f819-4e3e-8efe-bfc77f08c903.png)
